### PR TITLE
Add Python CLI packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN sudo vca-install-package \
   xz \
   pandoc \
   python-pandocfilters \
+  python-pypandoc \
   optipng \
   python-pylint \
   yapf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ RUN sudo vca-install-package \
   npm
 
 # Install NPM packages
-RUN sudo npm install -g markdownlint-cli
+RUN sudo npm install -g markdownlint-cli inquirer


### PR DESCRIPTION
Adds bindings for running pandoc from python and a command line package to read user input. This allows python scripts to be written
that parse the markdown.